### PR TITLE
Fix location history typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
                     <li> Deselect everything except Location History.
                         <ol>
                             <li> Click <strong>Deselect all</strong>.</li>
-                            <li> Scroll until you find <strong>History</strong> and select it.</li>
+                            <li> Scroll until you find <strong>Location History</strong> and select it.</li>
                             <li> Scroll down and click <strong>Next step</strong>.</li>
                         </ol>
                     </li> 


### PR DESCRIPTION
Appears as "Location History" in takeout menu, not "History"
![image](https://user-images.githubusercontent.com/4195424/105641122-4217cb80-5e37-11eb-9572-9367bbc57ae8.png)
